### PR TITLE
Fix "Digest initialization failed" on Ruby 2.3.0

### DIFF
--- a/digest-tiger/lib/digest/tiger/version.rb
+++ b/digest-tiger/lib/digest/tiger/version.rb
@@ -1,5 +1,5 @@
 module Digest
-  class Tiger
+  class Tiger < Digest::Base
     VERSION = "1.0.2"
   end
 end

--- a/digest-whirlpool/lib/digest/whirlpool/version.rb
+++ b/digest-whirlpool/lib/digest/whirlpool/version.rb
@@ -1,5 +1,5 @@
 module Digest
-  class Whirlpool
+  class Whirlpool < Digest::Base
     VERSION = "1.0.2"
   end
 end


### PR DESCRIPTION
This PR fixes "superclass mismatch for class Digest::Whirlpool (Object is given but was Digest::Base) (TypeError)" error, which I believe is caused by this change in Ruby 2.3.0 C API - 

> rb_define_class_id_under() now raises a TypeError exception when the
> class is already defined but its superclass does not match the given
> superclass, as well as definitions in ruby level.
