### PR TITLE
Fix for ruby 2.7.0 and implement tiger192,4

### DIFF
--- a/ext/digest/tiger/depend
+++ b/ext/digest/tiger/depend
@@ -1,4 +1,4 @@
 tiger.o: tiger.c tiger.h
 tiger_init.o: tiger.h \
-  $(hdrdir)/digest.h $(hdrdir)/ruby.h \
-  $(topdir)/config.h $(hdrdir)/defines.h $(hdrdir)/intern.h
+  $(hdrdir)/ruby/digest.h $(hdrdir)/ruby.h \
+  $(topdir)/config.h $(hdrdir)/ruby/defines.h $(hdrdir)/ruby/intern.h

--- a/ext/digest/tiger/tiger.h
+++ b/ext/digest/tiger/tiger.h
@@ -35,7 +35,7 @@ typedef unsigned LONG_LONG uint64_t;
 /* Three passes are recommended.                       */
 /* Use four passes when you need extra security.       */
 /* Must be at least three.                             */
-#define PASSES 3
+#define PASSES 4
 
 typedef struct {
     uint64_t state[3];


### PR DESCRIPTION
I don't expect this pull request to be approved as it changes the behaviour, just making the 2.7 fix a bit more visible to other users

I am thinking of implementing a proper fix so users can choose between tiger192,3 (current version) and tiger192,4